### PR TITLE
fix: consume rows as enumerable before ordering

### DIFF
--- a/Hammer/Services/MessageDeletionService.cs
+++ b/Hammer/Services/MessageDeletionService.cs
@@ -159,6 +159,7 @@ internal sealed class MessageDeletionService
 
         foreach (DeletedMessage deletedMessage in
                  context.DeletedMessages.Where(m => m.AuthorId == author.Id && m.GuildId == guild.Id)
+                     .AsEnumerable()
                      .OrderBy(m => m.DeletionTimestamp))
         {
             yield return deletedMessage;

--- a/Hammer/Services/MessageService.cs
+++ b/Hammer/Services/MessageService.cs
@@ -64,6 +64,7 @@ internal sealed class MessageService
 
         foreach (StaffMessage staffMessage in
                  context.StaffMessages.Where(m => m.RecipientId == recipient.Id && m.GuildId == guild.Id)
+                     .AsEnumerable()
                      .OrderBy(m => m.SentAt))
         {
             yield return staffMessage;


### PR DESCRIPTION
SQLite does not support OrderBy for DateTimeOffset properties.